### PR TITLE
Feature/confirm action tests

### DIFF
--- a/automated-tests/common/cypress/integration/Confirm.feature
+++ b/automated-tests/common/cypress/integration/Confirm.feature
@@ -31,7 +31,7 @@ Feature: Alert Action Validation
         Examples:
             | buttonTitle               | message                     |
             | JustAMessage              | ConfirmMessage              |
-            # | JustAMessageViaExpression | ConfirmMessageViaExpression |
+            | JustAMessageViaExpression | ConfirmMessageViaExpression |
 
     # Scenario Outline: Confirm 02 - Checks that a confirmation with a TITLE and a MESSAGE shows on the screen when set HARDCODED and via EXPRESSION
     #     When I press a confirm button with the <buttonTitle> title
@@ -42,15 +42,15 @@ Feature: Alert Action Validation
     #         | TitleAndMessage              | ConfirmTitle              | ConfirmMessage              |
     #         | TitleAndMessageViaExpression | ConfirmTitleViaExpression | ConfirmMessageViaExpression |
 
-    # Scenario: Confirm 03 - Checks that a the onPressOk method is triggered when the OK button is pressed to confirm component.
-    #     When I press an alert button with the TriggersAnActionWhenConfirmed title
-    #     Then I press the confirmation OK button on the confirm component
-    #     Then an alert with the Confirm ok clicked message should appear on the screen
+    Scenario: Confirm 03 - Checks that a the onPressOk method is triggered when the OK button is pressed to confirm component.
+        When I press an alert button with the TriggersAnActionWhenConfirmed title
+        # Then I press the confirmation OK button on the confirm component
+        Then an alert with the Confirm ok clicked message should appear on the screen
 
-    # Scenario: Confirm 04 - Checks that a the onPressCancel method is triggered when the Cancel button is pressed to confirm component.
-    #     When I press an alert button with the TriggersAnActionWhenCanceled title
-    #     Then I press the confirmation CANCEL button on the confirm component
-    #     Then an alert with the Confirm cancel clicked message should appear on the screen
+    Scenario: Confirm 04 - Checks that a the onPressCancel method is triggered when the Cancel button is pressed to confirm component.
+        When I press an alert button with the TriggersAnActionWhenCanceled title
+        # Then I press the confirmation CANCEL button on the confirm component
+        Then an alert with the Confirm cancel clicked message should appear on the screen
 
     # Scenario: Confirm 05 - Shows a Confirm message with customized text on the LabelOk and LabelCancel button.
     #     When I press an alert button with the CustomConfirmLabel title

--- a/automated-tests/common/cypress/integration/Confirm.feature
+++ b/automated-tests/common/cypress/integration/Confirm.feature
@@ -1,0 +1,57 @@
+#
+# Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+@confirm @regression
+Feature: Alert Action Validation
+
+    As a Beagle developer/user
+    I'd like to make sure my alert actions work as expected
+    In order to guarantee that my application never fails
+
+    Background:
+        Given the Beagle application did launch with the confirm screen url
+
+    Scenario Outline: Scenario Outline: Checks that a confirmation with just a message shows on the screen whenset HARDCODED and via EXPRESSION
+        When I press a confirm button with the <buttonTitle> title
+        Then a confirm with the <message> message should appear on the screen
+
+        Examples:
+            | buttonTitle               | message                     |
+            | JustAMessage              | ConfirmMessage              |
+            # | JustAMessageViaExpression | ConfirmMessageViaExpression |
+
+    # Scenario Outline: Confirm 02 - Checks that a confirmation with a TITLE and a MESSAGE shows on the screen when set HARDCODED and via EXPRESSION
+    #     When I press a confirm button with the <buttonTitle> title
+    #     Then a confirm with the <title> and <message> should appear on the screen
+
+    #     Examples:
+    #         | buttonTitle                  | title                     | message                     |
+    #         | TitleAndMessage              | ConfirmTitle              | ConfirmMessage              |
+    #         | TitleAndMessageViaExpression | ConfirmTitleViaExpression | ConfirmMessageViaExpression |
+
+    # Scenario: Confirm 03 - Checks that a the onPressOk method is triggered when the OK button is pressed to confirm component.
+    #     When I press an alert button with the TriggersAnActionWhenConfirmed title
+    #     Then I press the confirmation OK button on the confirm component
+    #     Then an alert with the Confirm ok clicked message should appear on the screen
+
+    # Scenario: Confirm 04 - Checks that a the onPressCancel method is triggered when the Cancel button is pressed to confirm component.
+    #     When I press an alert button with the TriggersAnActionWhenCanceled title
+    #     Then I press the confirmation CANCEL button on the confirm component
+    #     Then an alert with the Confirm cancel clicked message should appear on the screen
+
+    # Scenario: Confirm 05 - Shows a Confirm message with customized text on the LabelOk and LabelCancel button.
+    #     When I press an alert button with the CustomConfirmLabel title
+    #     Then a confirm with the CustomLabelOk and CustomLabelCancel should appear on the screen

--- a/automated-tests/common/cypress/integration/ConfirmScreen.feature
+++ b/automated-tests/common/cypress/integration/ConfirmScreen.feature
@@ -1,0 +1,58 @@
+#
+# Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+@confirm @regression
+Feature: Alert Action Validation
+
+    As a Beagle developer/user
+    I'd like to make sure my alert actions work as expected
+    In order to guarantee that my application never fails
+
+    Background:
+        Given the Beagle application did launch with the confirm screen url
+
+    Scenario Outline: Scenario Outline: Checks that a confirmation with just a message shows on the screen whenset HARDCODED and via EXPRESSION
+        When I press a confirm button with the <buttonTitle> title
+        Then a confirm with the <message> message should appear on the screen
+
+        Examples:
+            | buttonTitle               | message                     |
+            | JustAMessage              | ConfirmMessage              |
+            | JustAMessageViaExpression | ConfirmMessageViaExpression |
+
+    # Scenario Outline: Confirm 02 - Checks that a confirmation with a TITLE and a MESSAGE shows on the screen when set HARDCODED and via EXPRESSION
+    #     When I press a confirm button with the <buttonTitle> title
+    #     Then a confirm with the <title> and <message> should appear on the screen
+
+    #     Examples:
+    #         | buttonTitle                  | title                     | message                     |
+    #         | TitleAndMessage              | ConfirmTitle              | ConfirmMessage              |
+    #         | TitleAndMessageViaExpression | ConfirmTitleViaExpression | ConfirmMessageViaExpression |
+
+    Scenario: Confirm 03 - Checks that a the onPressOk method is triggered when the OK button is pressed to confirm component.
+        When I press an alert button with the TriggersAnActionWhenConfirmed title
+        # When I press the confirmation OK button on the confirm component
+        Then an alert with the Confirm ok clicked message should appear on the screen
+
+    Scenario: Confirm 04 - Checks that a the onPressCancel method is triggered when the Cancel button is pressed to confirm component.
+        Given that i'll cancel the confirmation window
+        When I press an alert button with the TriggersAnActionWhenCanceled title
+        And a confirm with the CancelMessage message should appear on the screen
+        Then an alert with the Confirm cancel clicked message should appear on the screen
+
+    # Scenario: Confirm 05 - Shows a Confirm message with customized text on the LabelOk and LabelCancel button.
+    #     When I press an alert button with the CustomConfirmLabel title
+    #     Then a confirm with the CustomLabelOk and CustomLabelCancel should appear on the screen

--- a/automated-tests/common/cypress/support/elements/confirm-elements.ts
+++ b/automated-tests/common/cypress/support/elements/confirm-elements.ts
@@ -15,9 +15,10 @@
  */
 
 const confirmElements = {
-    
-    buttonWithText: (text: string) => cy.contains('button', text)
+
+    buttonWithText: (text: string) => cy.contains('button', text),
    
+    clickFalse: () => cy.on('window:confirm', () => false)
 }
   
 export default confirmElements

--- a/automated-tests/common/cypress/support/elements/confirm-elements.ts
+++ b/automated-tests/common/cypress/support/elements/confirm-elements.ts
@@ -16,10 +16,8 @@
 
 const confirmElements = {
 
-    buttonWithText: (text: string) => cy.contains('button', text),
-   
-    clickFalse: () => cy.on('window:confirm', () => false)
+    buttonWithText: (text: string) => cy.contains('button', text)
 }
-  
+ 
 export default confirmElements
   

--- a/automated-tests/common/cypress/support/elements/confirm-elements.ts
+++ b/automated-tests/common/cypress/support/elements/confirm-elements.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const confirmElements = {
+    
+    buttonWithText: (text: string) => cy.contains('button', text)
+   
+}
+  
+export default confirmElements
+  

--- a/automated-tests/common/cypress/support/page-objects/ConfirmPage.ts
+++ b/automated-tests/common/cypress/support/page-objects/ConfirmPage.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import confirmElements from '../elements/confirm-elements'
+import BeaglePage from './BeaglePage'
+
+class ConfirmPage extends BeaglePage {
+    lastAlertMessage = ''
+
+    constructor() {
+        super('confirm')
+    }
+
+    init() {
+        return super.init().then(() => {
+          cy.on('window:alert', message => this.lastAlertMessage = message)
+        })
+    }
+
+    clickButtonByText(title: string) {
+        confirmElements.buttonWithText(title).click()
+    }
+
+    checkAlertMessage(message: String){
+        expect(this.lastAlertMessage).to.equal(message)
+    }
+
+}
+
+export default ConfirmPage

--- a/automated-tests/common/cypress/support/page-objects/ConfirmPage.ts
+++ b/automated-tests/common/cypress/support/page-objects/ConfirmPage.ts
@@ -26,8 +26,8 @@ class ConfirmPage extends BeaglePage {
 
     init() {
         return super.init().then(() => {
-          cy.on('window:alert', message => this.lastAlertMessage = message)
-        })
+            cy.on('window:confirm', (message) => this.lastAlertMessage = message)
+          })
     }
 
     clickButtonByText(title: string) {

--- a/automated-tests/common/cypress/support/page-objects/ConfirmPage.ts
+++ b/automated-tests/common/cypress/support/page-objects/ConfirmPage.ts
@@ -44,16 +44,12 @@ class ConfirmPage extends BeaglePage {
         expect(this.lastConfirmMessage).to.equal(message)
     }
 
-    clickCancel() {
-        confirmElements.clickFalse()
+    listenToConfirmationWindow(result: 'cancel' | 'confirm'){
+        cy.on('window:confirm', (message) => { 
+            this.lastConfirmMessage = message
+            return result === 'confirm'
+        })
     }
-
-    // it('Handling JS Confirm - Click Cancel', () => {
-    //     cy.contains('Click for JS Confirm').click()
-    //     cy.on('window:confirm', () => false);
-    //     cy.get('#result').contains('You clicked: Cancel')
-    // })
-
 
 }
 

--- a/automated-tests/common/cypress/support/page-objects/ConfirmPage.ts
+++ b/automated-tests/common/cypress/support/page-objects/ConfirmPage.ts
@@ -19,6 +19,7 @@ import BeaglePage from './BeaglePage'
 
 class ConfirmPage extends BeaglePage {
     lastAlertMessage = ''
+    lastConfirmMessage = ''
 
     constructor() {
         super('confirm')
@@ -26,7 +27,8 @@ class ConfirmPage extends BeaglePage {
 
     init() {
         return super.init().then(() => {
-            cy.on('window:confirm', (message) => this.lastAlertMessage = message)
+            cy.on('window:alert', (message) => this.lastAlertMessage = message)
+            cy.on('window:confirm', (message) => this.lastConfirmMessage = message)
           })
     }
 
@@ -37,6 +39,21 @@ class ConfirmPage extends BeaglePage {
     checkAlertMessage(message: String){
         expect(this.lastAlertMessage).to.equal(message)
     }
+
+    checkConfirmMessage(message: String){
+        expect(this.lastConfirmMessage).to.equal(message)
+    }
+
+    clickCancel() {
+        confirmElements.clickFalse()
+    }
+
+    // it('Handling JS Confirm - Click Cancel', () => {
+    //     cy.contains('Click for JS Confirm').click()
+    //     cy.on('window:confirm', () => false);
+    //     cy.get('#result').contains('You clicked: Cancel')
+    // })
+
 
 }
 

--- a/automated-tests/common/cypress/support/steps/confirm-step.ts
+++ b/automated-tests/common/cypress/support/steps/confirm-step.ts
@@ -27,5 +27,21 @@ When(/I press a confirm button with the (.*) title/, (buttonTitle) => {
 })
 
 Then(/a confirm with the (.*) message should appear on the screen/, (message) => {
+    confirmPage.checkConfirmMessage(message)
+})
+
+
+When(/I press an alert button with the (.*) title/, (buttonTitle) => {
+    confirmPage.clickButtonByText(buttonTitle)
+})
+
+
+Then(/an alert with the (.*) message should appear on the screen/, (message) => {
     confirmPage.checkAlertMessage(message)
+})
+
+
+
+Then("I press the confirmation CANCEL button on the confirm component", () => {
+    confirmPage.clickCancel()
 })

--- a/automated-tests/common/cypress/support/steps/confirm-step.ts
+++ b/automated-tests/common/cypress/support/steps/confirm-step.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import ConfirmPage from '../page-objects/ConfirmPage'
+
+const confirmPage = new ConfirmPage
+
+Given("the Beagle application did launch with the confirm screen url", () => {
+    confirmPage.init()
+})
+
+When(/I press a confirm button with the (.*) title/, (buttonTitle) => {
+    confirmPage.clickButtonByText(buttonTitle)
+})
+
+Then(/a confirm with the (.*) message should appear on the screen/, (message) => {
+    confirmPage.checkAlertMessage(message)
+})

--- a/automated-tests/common/cypress/support/steps/confirm-step.ts
+++ b/automated-tests/common/cypress/support/steps/confirm-step.ts
@@ -22,26 +22,22 @@ Given("the Beagle application did launch with the confirm screen url", () => {
     confirmPage.init()
 })
 
+Given(/that i'll (.*) the confirmation window/, (result: 'cancel' | 'confirm') => {
+    confirmPage.listenToConfirmationWindow(result)
+})
+
 When(/I press a confirm button with the (.*) title/, (buttonTitle) => {
     confirmPage.clickButtonByText(buttonTitle)
 })
 
-Then(/a confirm with the (.*) message should appear on the screen/, (message) => {
+And(/a confirm with the (.*) message should appear on the screen/, (message) => {
     confirmPage.checkConfirmMessage(message)
 })
 
-
-When(/I press an alert button with the (.*) title/, (buttonTitle) => {
+When(/I press an alert button with the (.*) title/, (buttonTitle) => {  
     confirmPage.clickButtonByText(buttonTitle)
 })
 
-
-Then(/an alert with the (.*) message should appear on the screen/, (message) => {
+And(/an alert with the (.*) message should appear on the screen/, (message) => {
     confirmPage.checkAlertMessage(message)
-})
-
-
-
-Then("I press the confirmation CANCEL button on the confirm component", () => {
-    confirmPage.clickCancel()
 })


### PR DESCRIPTION
**This feature depends on merge this PR #34**

- What I did
I created the tests for the Confirm action.

- How I did it
I created the tests for the Confirm action using cypress and cucumber.

- How to verify it
Running yarn test:angular:9 TAGS="@confirm" or yarn cypress:open 

- Branch:
The bff of these test are in the branch confirm-tests of the monorepo