### PR TITLE
fix: waits for angular9 app startup before starting tests

### DIFF
--- a/.github/workflows/automatedTests_angular9.yml
+++ b/.github/workflows/automatedTests_angular9.yml
@@ -97,7 +97,7 @@ jobs:
           yarn --prefer-offline
           dos2unix -F node_modules/.bin/beagle
           nohup yarn start > angular9log.txt 2>&1 &
-          sleep 90
+          sleep 30
 
       - name: Run angular 9 app tests
         working-directory: automated-tests/common

--- a/.github/workflows/automatedTests_angular9.yml
+++ b/.github/workflows/automatedTests_angular9.yml
@@ -96,8 +96,8 @@ jobs:
           brew install dos2unix
           yarn --prefer-offline
           dos2unix -F node_modules/.bin/beagle
-          nohup yarn start 2>&1 &
-          sleep 60
+          nohup yarn start 2>&1 > angular9log.txt > &
+          sleep 90
 
       - name: Run angular 9 app tests
         working-directory: automated-tests/common
@@ -105,14 +105,15 @@ jobs:
           yarn --prefer-offline
           yarn test:angular:9
 
-      - name: Expose failed test screenshot files
+      - name: Expose failed test screenshot and other files
         if: failure()
         uses: actions/upload-artifact@v2
         with:
-          name: failed_tests_screenshots
+          name: failed_tests_screenshots_and_other_files
           path: |
             automated-tests/common/cypress/screenshots/
-            automated-tests/common/cypress/snapshots/*/__diff_output__/            
+            automated-tests/common/cypress/snapshots/*/__diff_output__/
+            automated-tests/angular9/angular9log.txt            
 
                 
       

--- a/.github/workflows/automatedTests_angular9.yml
+++ b/.github/workflows/automatedTests_angular9.yml
@@ -105,11 +105,11 @@ jobs:
           yarn --prefer-offline
           yarn test:angular:9
 
-      - name: Expose failed test screenshot and other files
+      - name: Expose failed test screenshot and angular 9 app log
         if: failure()
         uses: actions/upload-artifact@v2
         with:
-          name: failed_tests_screenshots_and_other_files
+          name: failed_tests_screenshots_and_angular_app_log
           path: |
             automated-tests/common/cypress/screenshots/
             automated-tests/common/cypress/snapshots/*/__diff_output__/

--- a/.github/workflows/automatedTests_angular9.yml
+++ b/.github/workflows/automatedTests_angular9.yml
@@ -96,7 +96,7 @@ jobs:
           brew install dos2unix
           yarn --prefer-offline
           dos2unix -F node_modules/.bin/beagle
-          nohup yarn start 2>&1 > angular9log.txt > &
+          nohup yarn start > angular9log.txt > 2>&1
           sleep 90
 
       - name: Run angular 9 app tests

--- a/.github/workflows/automatedTests_angular9.yml
+++ b/.github/workflows/automatedTests_angular9.yml
@@ -17,21 +17,21 @@
 name: Beagle Angular 9 Automated Tests
 
 
-#on: workflow_dispatch
+on: workflow_dispatch
 # Bellow configuration is for testing this workflow without merging to main
-on:
- push:
-   branches:
-     - master
-   paths:
-     - 'automated-tests/**'
-     - '.github/**'
- pull_request:
-   branches:
-     - master
-   paths:
-     - 'automated-tests/**'
-     - '.github/**'
+# on:
+#  push:
+#    branches:
+#      - master
+#    paths:
+#      - 'automated-tests/**'
+#      - '.github/**'
+#  pull_request:
+#    branches:
+#      - master
+#    paths:
+#      - 'automated-tests/**'
+#      - '.github/**'
 
 jobs:
   angular9_tests:

--- a/.github/workflows/automatedTests_angular9.yml
+++ b/.github/workflows/automatedTests_angular9.yml
@@ -17,21 +17,21 @@
 name: Beagle Angular 9 Automated Tests
 
 
-on: workflow_dispatch
+#on: workflow_dispatch
 # Bellow configuration is for testing this workflow without merging to main
-# on:
-#  push:
-#    branches:
-#      - main
-#    paths:
-#      - 'automated-tests/**'
-#      - '.github/**'
-#  pull_request:
-#    branches:
-#      - main
-#    paths:
-#      - 'automated-tests/**'
-#      - '.github/**'
+on:
+ push:
+   branches:
+     - master
+   paths:
+     - 'automated-tests/**'
+     - '.github/**'
+ pull_request:
+   branches:
+     - master
+   paths:
+     - 'automated-tests/**'
+     - '.github/**'
 
 jobs:
   angular9_tests:
@@ -97,6 +97,7 @@ jobs:
           yarn --prefer-offline
           dos2unix -F node_modules/.bin/beagle
           nohup yarn start 2>&1 &
+          sleep 30
 
       - name: Run angular 9 app tests
         working-directory: automated-tests/common

--- a/.github/workflows/automatedTests_angular9.yml
+++ b/.github/workflows/automatedTests_angular9.yml
@@ -97,7 +97,7 @@ jobs:
           yarn --prefer-offline
           dos2unix -F node_modules/.bin/beagle
           nohup yarn start 2>&1 &
-          sleep 30
+          sleep 60
 
       - name: Run angular 9 app tests
         working-directory: automated-tests/common

--- a/.github/workflows/automatedTests_angular9.yml
+++ b/.github/workflows/automatedTests_angular9.yml
@@ -96,7 +96,7 @@ jobs:
           brew install dos2unix
           yarn --prefer-offline
           dos2unix -F node_modules/.bin/beagle
-          nohup yarn start > angular9log.txt > 2>&1
+          nohup yarn start > angular9log.txt 2>&1 &
           sleep 90
 
       - name: Run angular 9 app tests


### PR DESCRIPTION
### Related issue

https://github.com/ZupIT/beagle-web-components/issues/67

### Description

- Waits 30s before initializing tests, giving some extra time for the project angular9 to compile
- Puts angular9 app log inside a file, so that when the tests fail, this log file can be retrieved